### PR TITLE
Jacky/python versions

### DIFF
--- a/make_scripts/make_view_cpp.sh
+++ b/make_scripts/make_view_cpp.sh
@@ -44,10 +44,10 @@ cd ../..
 
 # Copy .so files to python bindings
 echo "Copying shared libraries to python bindings"
-src_dir=cpp/build/ 
+src_dir=cpp/build
 target_dir=python/pillar_state/_bindings/linux-x86_64
 
 mkdir -p $target_dir
 
-cp $src_dir\/libpillar_state.so $target_dir
-cp $src_dir\/pillar_state_py.*.so $target_dir\/pillar_state_py.so
+cp -a $src_dir/libpillar_state.so $target_dir
+cp -a $src_dir/pillar_state_py.*.so $target_dir/pillar_state_py.so


### PR DESCRIPTION
This merge enables PILLAR State to work with both Python 3.6 and 3.7.

Tested on a platform that has both Python 3.6 and 3.7 installed:
- Installed two separate virtualenvs, one for 3.6 and one for 3.7
- For each virtual env, do a clean build and run unit tests for CPP and Python
- All unit tests passed

This PR will close #10.